### PR TITLE
feat: limited support for 9 char sitenames in filenames GSR-569

### DIFF
--- a/bin/igslog_to_sta
+++ b/bin/igslog_to_sta
@@ -59,7 +59,7 @@ if( $logfilere ne '')
     {
         my $r = $p eq '*'      ? '.*' :
              $p eq '?'      ? '.' :
-             $p eq '{code}' ? '(?<code>\w\w\w\w)' :
+             $p eq '{code}' ? '(?<code>\w\w\w\w)(?:\w{5})?' :
              $p eq '{yyyy}' ? '(?<year>(?:19|20)\d\d)' :
              $p eq '{mm}'   ? '(?<month>(?:0[1-9]|10|11|12))' :
              $p eq '{dd}'   ? '(?<day>(?:0[1-9]|[12]\d|30|31))' :


### PR DESCRIPTION
This adds support for 9 character site codes in sitelog file names.  Actually using 9 character ids also requires updates in [liblinz-gnss-perl](https://github.com/linz/liblinz-gnss-perl/pull/7)